### PR TITLE
Fix compilation issues on zig master

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -30,9 +30,9 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(lib);
 
     const module = b.addModule("smithy", .{
-        .source_file = .{ .path = "src/smithy.zig" },
+        .root_source_file = .{ .path = "src/smithy.zig" },
     });
-    lib.addModule("smithy", module);
+    lib.root_module.addImport("smithy", module);
 
     // Creates a step for unit testing. This only builds the test executable
     // but does not run it.

--- a/src/smithy.zig
+++ b/src/smithy.zig
@@ -7,14 +7,16 @@ pub const Smithy = struct {
     metadata: ModelMetadata,
     shapes: []ShapeInfo,
     allocator: std.mem.Allocator,
+    json_source: std.json.Parsed(std.json.Value),
 
     const Self = @This();
-    pub fn init(allocator: std.mem.Allocator, version: []const u8, metadata: ModelMetadata, shapeinfo: []ShapeInfo) Smithy {
+    pub fn init(allocator: std.mem.Allocator, version: []const u8, metadata: ModelMetadata, shapeinfo: []ShapeInfo, json_source: std.json.Parsed(std.json.Value)) Smithy {
         return .{
             .version = version,
             .metadata = metadata,
             .shapes = shapeinfo,
             .allocator = allocator,
+            .json_source = json_source,
         };
     }
     pub fn deinit(self: Self) void {
@@ -68,6 +70,7 @@ pub const Smithy = struct {
             }
         }
         self.allocator.free(self.shapes);
+        self.json_source.deinit();
     }
 };
 pub const ShapeInfo = struct {
@@ -91,13 +94,13 @@ pub const TraitType = enum {
     aws_auth_sigv4,
     aws_protocol,
     ec2_query_name,
+    json_name,
+    xml_name,
     http,
     http_header,
     http_label,
     http_query,
     http_payload,
-    json_name,
-    xml_name,
     required,
     documentation,
     pattern,
@@ -238,10 +241,10 @@ pub const AwsProtocol = enum {
 };
 
 pub fn parse(allocator: std.mem.Allocator, json_model: []const u8) !Smithy {
-    // construct a parser. We're not copying strings here, but that may
-    // be a poor decision
+    // construct a parser. We're not copying strings here
+    // Instead, we keep the original json string around
+    // This might be bad if we only need a small fraction of the original json source
     var vt = try std.json.parseFromSlice(std.json.Value, allocator, json_model, .{});
-    defer vt.deinit();
     return Smithy.init(
         allocator,
         vt.value.object.get("smithy").?.string,
@@ -250,6 +253,7 @@ pub fn parse(allocator: std.mem.Allocator, json_model: []const u8) !Smithy {
             .suppressions = &.{},
         },
         try shapes(allocator, vt.value.object.get("shapes").?.object),
+        vt,
     );
 }
 
@@ -432,7 +436,7 @@ fn getShape(allocator: std.mem.Allocator, shape: std.json.Value) SmithyParseErro
 }
 
 fn parseMembers(allocator: std.mem.Allocator, shape: ?std.json.Value) SmithyParseError![]TypeMember {
-    var rc: []TypeMember = &.{};
+    const rc: []TypeMember = &.{};
     if (shape == null)
         return rc;
 
@@ -466,7 +470,7 @@ fn parseTraitsOnly(allocator: std.mem.Allocator, shape: std.json.Value) SmithyPa
 }
 
 fn parseTraits(allocator: std.mem.Allocator, shape: ?std.json.Value) SmithyParseError![]Trait {
-    var rc: []Trait = &.{};
+    const rc: []Trait = &.{};
     if (shape == null)
         return rc;
 


### PR DESCRIPTION
Hi @elerch,
I want to use the aws-sdk-for-zig for a project that I am developing on zig master.
These where the changes required to compile on `0.12.0-dev.2150+63de8a598`.
As I cannot open a PR on your self-hosted Gitea instance, I am opening this PR on the github mirror repository.
Happy to contribute also in future if you accept PRs.
